### PR TITLE
DRAFT: Propose an alternative to the types in capacity_types.go

### DIFF
--- a/k8srm-prototype/pkg/api/capacity_types_alternate.go
+++ b/k8srm-prototype/pkg/api/capacity_types_alternate.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DevMgmtAPIVersion = "devmgmtproto.k8s.io/v1alpha1"
+)
+
+// DevicePool represents a collection of devices managed by a given driver. How
+// devices are divided into pools is driver-specific, but typically the
+// expectation would a be a pool per identical collection of devices, per node.
+// It is fine to have more than one pool for a given node, for the same driver.
+type DevicePool struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   DevicePoolSpec   `json:"spec,omitempty"`
+	Status DevicePoolStatus `json:"status,omitempty"`
+}
+
+// DevicePoolSpec identifies the driver and contains the data for the pool
+// prior to any allocations.
+// NOTE: It's not clear that spec/status is the right model for this data.
+type DevicePoolSpec struct {
+	// NodeName is the name of the node containing the devices in the pool.
+	// For network attached devices, this may be empty.
+	// +optional
+	NodeName *string `json:"nodeName,omitempty"`
+
+	// Driver is the name of the DeviceDriver that created this object and
+	// owns the data in it.
+	//
+	// +required
+	DriverName string `json:"driverName"`
+
+	// Attributes contains device attributes that are common to all devices
+	// in the pool.
+	//
+	// +optional
+	Attributes []Attribute `json:"attributes,omitempty"`
+
+	// SharedResources are resources that are shared by all devices in the
+	// pool. This is typically used when representing a partitionable
+	// device, and need not be populated otherwise.
+	//
+	// +optional
+	SharedResources []DeviceResource `json:"sharedResources,omitempty"`
+
+	// Devices contains the individual devices in the pool.
+	//
+	// +required
+	Devices []Device `json:"devices"`
+}
+
+// DevicePoolStatus contains the state of the pool as last reported by the
+// driver. Note that this will not include the allocations that have been made
+// by the scheduler but not yet seen by the driver. Thus, it is NOT sufficient
+// to make future scheduling decisions.
+type DevicePoolStatus struct {
+	AllocatedDevices []AllocatedDevice `json:"allocatedDevices,omitempty"`
+}
+
+// AllocatedDevice represents a device that has been allocated from the pool.
+type AllocatedDevice struct {
+	Name string
+	ClaimUID types.UID
+}
+
+// Device is used to track individual devices in a pool.
+type Device struct {
+	// Name is a driver-specific identifier for the device.
+	//
+	// +required
+	Name string `json:"name"`
+
+	// Attributes contain additional metadata that can be used in
+	// constraints. If an attribute name overlaps with the pool attribute,
+	// the device attribute takes precedence.
+	//
+	// +optional
+	Attributes []Attribute `json:"attributes,omitempty"`
+
+	// SharedResourceRequests contains requests for some subset of the shared
+	// resources available in the overall pool. They represent the set of
+	// shared resources consumed by this device when it gets allocated.
+	//
+	// +optional
+	SharedResourceRequests []DeviceResourceRequest `json:"sharedResourceRequests,omitempty"`
+}
+
+// DeviceResource represents a named resource that is consumable by a device.
+// We indirect through DeviceResourceValue to enforce a one-of-many for the
+// different types of resources this struct can represent.
+type DeviceResource struct {
+	Name string `json:"name"`
+	*DeviceResourceValue `json:",inline"`
+}
+
+// DeviceResourceValue holds the actual value of the named device resource.
+// Only one of the fields in this struct can be set for any given instance.
+//
+// +kubebuilder:validation:MaxProperties=1
+type DeviceResourceValue struct {
+	Quantity *DeviceResourceQuantity `json:"quantity"`
+	IntRange *DeviceResourceIntRange `json:"intrange"`
+}
+
+// DeviceResourceRequest represents a request to consume a named resource
+// from a device. We indirect through DeviceResourcRequestValue to enforce a
+// one-of-many for the different types of resources this struct can represent.
+type DeviceResourceRequest struct {
+	Name string `json:"name"`
+	*DeviceResourceRequestValue `json:",inline"`
+}
+
+// DeviceResourceRequestValue holds the actual value of the request for the
+// named device resource. Only one of the fields in this struct can be set for
+// any given instance.
+//
+// +kubebuilder:validation:MaxProperties=1
+type DeviceResourceRequestValue struct {
+	Quantity *resource.Quantity `json:"quantity"`
+	IntRange *resource.IntRange `json:"intrange"`
+}
+
+// DeviceResourceQuantity represents a consumable resource on a device as a
+// quantity that is allocatable with a given block size.
+type DeviceResourceQuantity struct {
+	// Value represents the actual quantity that this resource holds.
+	//
+	// +required
+	Value resource.Quantity `json:"value"`
+
+	// BlockSize is the increments in which quantity is consumed. For
+	// example, if you can only allocate memory in 4k pages, then the
+	// block size should be "4Ki". Default is 1.
+	//
+	// If the resource is consumable in a fractional way, then the
+	// default of 1 should not be used; instead this should be a fractional
+	// amount corresponding the increment size. We may also need a minimum
+	// value, if the minimum is larger than the block size (as is the case
+	// for standard Kubernetes CPU resources).
+	//
+	// +optional
+	BlockSize *resource.Quantity `json:"blockSize,omitempty"`
+}
+
+// DeviceResourceIntRange represents a consumable resource on a device as a
+// discrete range of integers.
+type DeviceResourceIntRange struct {
+	// Value represents the actual range of integers that this resource holds.
+	//
+	// +required
+	Value resource.IntRange `json:"value"`
+}
+
+// DeviceAttribute capture the name, value, and type of a device attribute.
+// We indirect through DeviceAttributeValue to enforce a one-of-many for the
+// different types of attributes this struct can represent.
+type DeviceAttribute struct {
+	Name string `json:"name"`
+	*DeviceAttributeValue `json:",inline"`
+}
+
+// DeviceAttributeValue holds the actual value of the attribute for the device.
+// Only one of the fields in this struct can be set for any given instance.
+//
+// +kubebuilder:validation:MaxProperties=1
+type DeviceAttributeValue struct {
+	StringValue   *string            `json:"string,omitempty"`
+	IntValue      *int               `json:"int,omitempty"`
+	QuantityValue *resource.Quantity `json:"quantity,omitempty"`
+	SemVerValue   *SemVer            `json:"semver,omitempty"`
+}


### PR DESCRIPTION
I spent some time today going through the types in the file `pkg/api/capacity_types.go` in detail. I have proposed my changes to it as an entirely new file (instead of a diff to the original) so that we can more easily comment on it line-by-line without the diff getting in the way.

**The biggest thing to note is the following:**
I'm coming around to the idea that `DevicePool` (or whatever future resource models we come up with) _**could**_ be 
top level objects, rather than wrapping them in multiple-levels of indirection like we have today to support the `NamedResources` model:
```
type ResourceSlice struct {
	metav1.TypeMeta
	metav1.ObjectMeta

	NodeName string `json:"nodeName,omitempty" protobuf:"bytes,2,opt,name=nodeName"`
	DriverName string `json:"driverName" protobuf:"bytes,3,name=driverName"`
	ResourceModel `json:",inline" protobuf:"bytes,4,name=resourceModel"`
}

type ResourceModel struct {
	NamedResources *NamedResourcesResources
}

type NamedResourcesResources struct {
	Instances []NamedResourcesInstance `json:"instances" protobuf:"bytes,1,name=instances"`
}
```

Having all of these levels of indirection doesn't actually add much value. The original idea was that the scheduler (or whoever else cares about `ResourceSlices`) only has one object type to subscribe to, and we can simply extend its embedded `ResourceModel` with more types over time.

This actually makes it awkward, however, when we need to split our `Instances` at the lowest level across multiple API server objects. Each object needs to be wrapped in multiple levels of indirection, making it a somewhat hard to reason about when trying to reconstruct all objects from a given driver.

On the contrary, by making `DevicePool` (or whatever future resource models we come up with) a top-level API server object, we have a natural way of breaking things apart. Each pool is it's own self-contained object, so there is no ambiguity on where the object boundaries should be. After thinking about it for a while, this actually feels like the more natural and "Kubernetes-like" way of abstracting these objects.

The major difference being that now the scheduler can't just subscribe to a single `ResourceSlices` object and have all supported model implementations from all drivers follow that. It potentially has to subscribe to multiple top-level objects representing different models and react to them accordingly. This seems like a reasonable trade-off since one would always have to write the code to be aware of the different models anyway.

**The second biggest thing to note is the following:**
I have (slightly) renamed and "future-proofed" all of the types that represent named resources and their requests. Whether we want to do this is still being debated, but I wanted to get a concrete proposal for what it would look like as a diff to @johnbelamaric's prototype, rather than continuing to talk in "what-ifs".

**The third biggest thing to note is the following:**
We can now have a meaningful `Status` attached to the top-level type. In this case I have expanded it to include all allocated devices and the claims they have been allocated to.

