### PR TITLE
dra-evolution: restore minimal support for "classic DRA"

### DIFF
--- a/dra-evolution/pkg/api/claim_types.go
+++ b/dra-evolution/pkg/api/claim_types.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // DeviceClass is a vendor or admin-provided resource that contains
@@ -401,14 +402,27 @@ type RequestAllocationResult struct {
 	// device to be allocated.
 	RequestName string `json:"requestName"`
 
-	// This node name together with the driver name and
-	// the device name field identify which device was allocated.
-	NodeName string `json:"nodeName"`
+	// This name together with the driver name and the device name field
+	// identify which device was allocated.
+	//
+	// For a driver with node-local devices, it is the name of the node and
+	// the overall ID is `<driver name>/<node name>/<device name>`.
+	//
+	// For other drivers, the overall ID is `<driver name>/<device pool
+	// name>/<device name>`.
+	//
+	// Must not be longer than 253 characters and may contain one or more
+	// DNS sub-domains separated by slashes.
+	//
+	// +optional
+	DevicePoolName string `json:"devicePoolName,omitempty"`
 
 	// DeviceName references one device instance via its name in the driver's
-	// resource pool.
+	// resource pool. It must be a DNS label.
 	DeviceName string `json:"deviceName"`
 }
+
+const DevicePoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 
 // DeviceConfiguration is one entry in a list of configuration pieces for a device.
 type DeviceConfiguration struct {

--- a/dra-evolution/pkg/api/claim_types.go
+++ b/dra-evolution/pkg/api/claim_types.go
@@ -322,8 +322,8 @@ type AllocationResult struct {
 	// involving a driver.
 	//
 	// A driver may allocate devices provided by other drivers, so this
-	// driver name here can be different from the driver names listed in
-	// DriverData.
+	// driver name here can be different from the driver names listed for
+	// the results.
 	//
 	// This is an alpha field and requires enabling the DRAControlPlaneController
 	// feature gate.
@@ -353,27 +353,6 @@ type AllocationResult struct {
 	//
 	// +optional
 	Shareable bool `json:"shareable,omitempty" protobuf:"varint,3,opt,name=shareable"`
-}
-
-// DriverData holds information for processing by a specific kubelet plugin.
-type DriverData struct {
-	// DriverName specifies the name of the DRA driver whose kubelet
-	// plugin should be invoked to process the allocation once the claim is
-	// needed on a node.
-	//
-	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
-	DriverName string `json:"driverName" protobuf:"bytes,1,name=driverName"`
-
-	// Config contains all the configuration pieces that apply to the entire claim
-	// and that were meant for the driver which handles these devices.
-	// They get collected during the allocation and stored here
-	// to ensure that they remain available while the claim is allocated.
-	//
-	// Entries are listed in the same order as in claim.config.
-	//
-	// +optional
-	Config []DriverConfigurationParameters `json:"config,omitempty"`
 }
 
 // RequestAllocationResult contains configuration and the allocation result for

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -57,8 +57,10 @@ spec:
   constraints:
   - matchAttribute: dra.k8s.io/pcie_root
   requests:
-  - deviceClassName: foozer.example.com
-  - deviceClassName: sriov-nic-example.org
+  - name: gpu
+    deviceClassName: foozer.example.com
+  - name: nic
+    deviceClassName: sriov-nic-example.org
     requirements:
     - deviceSelector: "device.stringAttributes['sriov-nic.example.org/sriovType'] == 'vf'"
 status:
@@ -72,11 +74,13 @@ status:
           - worker-1
     shareable: true
     results:
-    - driverName: foozer.example.com
-      nodeName: worker-1
+    - requestName: gpu
+      driverName: foozer.example.com
+      devicePoolName: worker-1
       deviceName: gpu-1
-    - driverName: sriov.example.org
-      nodeName: worker-1
+    - requestName: nic
+      driverName: sriov.example.org
+      devicePoolName: worker-1
       deviceName: nic-1
   reservedFor:
   - resource: pods

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -63,17 +63,23 @@ spec:
     - deviceSelector: "device.stringAttributes['sriov-nic.example.org/sriovType'] == 'vf'"
 status:
   allocation:
-    nodeName: worker-1
+    availableOnNodes:
+      nodeSelectorTerms:
+      - matchFields:
+        - key: name
+          operator: in
+          values:
+          - worker-1
     shareable: true
     driverData:
     - driverName: foozer.example.com
-      data:
-        results:
-        - deviceName: gpu-1
+      results:
+      - nodeName: worker-1
+        deviceName: gpu-1
     - driverName: sriov.example.org
-      data:
-        results:
-        - deviceName: nic-1
+      results:
+      - nodeName: worker-1
+        deviceName: nic-1
   reservedFor:
   - resource: pods
     name: foozer

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -71,15 +71,13 @@ status:
           values:
           - worker-1
     shareable: true
-    driverData:
+    results:
     - driverName: foozer.example.com
-      results:
-      - nodeName: worker-1
-        deviceName: gpu-1
+      nodeName: worker-1
+      deviceName: gpu-1
     - driverName: sriov.example.org
-      results:
-      - nodeName: worker-1
-        deviceName: nic-1
+      nodeName: worker-1
+      deviceName: nic-1
   reservedFor:
   - resource: pods
     name: foozer


### PR DESCRIPTION
"Classic DRA" has a control plane controller which handles allocation and deallocation of a claim in cooperation with the scheduler. That is the part which gets added back to the API.

What doesn't get restored compared to v1.30.0 is:
- immediate allocation
- using a CRD as user-facing API
- the opaque "resource handle" in the allocation result

Drivers which want to support this mode of operation have to use the in-tree types. The "config" fields support that, albeit perhaps with a slightly less natural API.

While at it, some occurrences of "resource" get replaced with "device" or "DRA".

/assign @thockin @klueska 