### PR TITLE
WIP: dra-evolution: network-attached devices

### DIFF
--- a/dra-evolution/pkg/api/claim_types.go
+++ b/dra-evolution/pkg/api/claim_types.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // DeviceClass is a vendor or admin-provided resource that contains
@@ -401,14 +402,27 @@ type RequestAllocationResult struct {
 	// device to be allocated.
 	RequestName string `json:"requestName"`
 
-	// This node name together with the driver name and
-	// the device name field identify which device was allocated.
-	NodeName string `json:"nodeName"`
+	// This name together with the driver name and the device name field
+	// identify which device was allocated.
+	//
+	// For a driver with node-local devices, it is the name of the node and
+	// the overall ID is `<driver name>/<node name>/<device name>`.
+	//
+	// For other drivers, the overall ID is `<driver name>/<device pool
+	// name>/<device name>`.
+	//
+	// Must not be longer than 253 characters and may contain one or more
+	// DNS sub-domains separated by slashes.
+	//
+	// +optional
+	DevicePoolName string `json:"devicePoolName,omitempty"`
 
 	// DeviceName references one device instance via its name in the driver's
-	// resource pool.
+	// resource pool. It must be a DNS label.
 	DeviceName string `json:"deviceName"`
 }
+
+const DevicePoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 
 // DeviceConfiguration is one entry in a list of configuration pieces for a device.
 type DeviceConfiguration struct {

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -57,8 +57,10 @@ spec:
   constraints:
   - matchAttribute: dra.k8s.io/pcie_root
   requests:
-  - deviceClassName: foozer.example.com
-  - deviceClassName: sriov-nic-example.org
+  - name: gpu
+    deviceClassName: foozer.example.com
+  - name: nic
+    deviceClassName: sriov-nic-example.org
     requirements:
     - deviceSelector: "device.stringAttributes['sriov-nic.example.org/sriovType'] == 'vf'"
 status:
@@ -72,11 +74,13 @@ status:
           - worker-1
     shareable: true
     results:
-    - driverName: foozer.example.com
-      nodeName: worker-1
+    - requestName: gpu
+      driverName: foozer.example.com
+      devicePoolName: worker-1
       deviceName: gpu-1
-    - driverName: sriov.example.org
-      nodeName: worker-1
+    - requestName: nic
+      driverName: sriov.example.org
+      devicePoolName: worker-1
       deviceName: nic-1
   reservedFor:
   - resource: pods

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -63,17 +63,23 @@ spec:
     - deviceSelector: "device.stringAttributes['sriov-nic.example.org/sriovType'] == 'vf'"
 status:
   allocation:
-    nodeName: worker-1
+    availableOnNodes:
+      nodeSelectorTerms:
+      - matchFields:
+        - key: name
+          operator: in
+          values:
+          - worker-1
     shareable: true
     driverData:
     - driverName: foozer.example.com
-      data:
-        results:
-        - deviceName: gpu-1
+      results:
+      - nodeName: worker-1
+        deviceName: gpu-1
     - driverName: sriov.example.org
-      data:
-        results:
-        - deviceName: nic-1
+      results:
+      - nodeName: worker-1
+        deviceName: nic-1
   reservedFor:
   - resource: pods
     name: foozer

--- a/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
+++ b/dra-evolution/testdata/pod-one-container-one-gpu-one-vf.yaml
@@ -71,15 +71,13 @@ status:
           values:
           - worker-1
     shareable: true
-    driverData:
+    results:
     - driverName: foozer.example.com
-      results:
-      - nodeName: worker-1
-        deviceName: gpu-1
+      nodeName: worker-1
+      deviceName: gpu-1
     - driverName: sriov.example.org
-      results:
-      - nodeName: worker-1
-        deviceName: nic-1
+      nodeName: worker-1
+      deviceName: nic-1
   reservedFor:
   - resource: pods
     name: foozer


### PR DESCRIPTION
This builds on top of the support for network-attached devices in classic DRA (https://github.com/kubernetes-sigs/wg-device-management/pull/26).

I'm not proposing this for 1.31. I just want to show what the ResourcePool change could look like.
